### PR TITLE
Catch only E185 exception

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -325,7 +325,7 @@ endif
 
 try
   colorscheme Tomorrow-Night
-catch
+catch /^Vim\%((\a\+)\)\=:E185/
   colorscheme default
   set background=dark
 endtry


### PR DESCRIPTION
기존 코드에서는, `colorscheme Tomorrow-Night` 커맨드를 실행하는 동안
발생하는 모든 예외를 잡지만, 이 수정을 적용시키고 난 뒤에는
`Tomorrow-Night 테마를 찾을 수 없습니다` 오로지 이 한 예외만 잡습니다.