### PR TITLE
Modify link command not to make ycm_extra_conf.py

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -105,7 +105,6 @@ install_link() {
     'tmux.conf' \
     'vintrc.yaml' \
     'vimrc' \
-    'ycm_extra_conf.py' \
     'zprofile' \
     'zshrc'
   do


### PR DESCRIPTION
Even though `YCM` plugin has been removed, the symbolic link for `ycm_extra_conf.py` is still generated.